### PR TITLE
[deploy] Disable automatic deploy for security reasons

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,9 +119,9 @@ workflows:
   main:
     jobs:
       - test
-      - deploy:
-          requires:
-            - test
-          filters:
-            tags:
-              only: /v.*/
+#      - deploy:
+#          requires:
+#            - test
+#          filters:
+#            tags:
+#              only: /v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,11 +105,11 @@ jobs:
           docker_layer_caching: true
       - run: *install_dependencies
       - run:
-          name: Build application Docker image (if need to deploy)
+          name: Build application Docker image
           command: |
             make image_build
       - run:
-          name: Publish Docker Image to Docker Hub (if have a version tag)
+          name: Publish Docker Image to Docker Hub
           command: |
             make dockerhub_login
             make image_deploy


### PR DESCRIPTION
Problem: 

Since we published this project, a security flaw appeared: we store dockerhub credentials in CircleCI env vars, thus anyone can update `neuromation/base` by submitting a build in a custom branch that triggers deployment.

In this PR, we disable automatic deploy. Also, I will delete dockerhub credentials from CircleCI. 

cc @astaff @mariyadavydova @anayden 