### PR TITLE
Return back insecure SSH

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 
+if [ ! -z "$EXPOSE_SSH" ]; then
+  echo "Starting SSH server"
+  /usr/sbin/sshd -e
+fi
+
 # run command
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 if [ ! -z "$EXPOSE_SSH" ]; then
-  echo "Starting SSH server"
   /usr/sbin/sshd -e
 fi
 

--- a/targets/python37-jupyter-pytorch-tensorflow-jupyterlab/Dockerfile
+++ b/targets/python37-jupyter-pytorch-tensorflow-jupyterlab/Dockerfile
@@ -190,7 +190,7 @@ COPY files/var/notebooks/README.ipynb /var/notebooks
 # ------------------------------------------------------------------
 
 # Setup environment for ssh session
-RUN  $APT_INSTALL openssh-server && \
+RUN apt-get install -y --no-install-recommends openssh-server && \
  echo "export PATH=$PATH" >> /etc/profile && \
  echo "export LANG=$LANG" >> /etc/profile && \
  echo "export LANGUAGE=$LANGUAGE" >> /etc/profile && \

--- a/targets/python37-jupyter-pytorch-tensorflow-jupyterlab/Dockerfile
+++ b/targets/python37-jupyter-pytorch-tensorflow-jupyterlab/Dockerfile
@@ -186,6 +186,35 @@ COPY files/var/notebooks/README.ipynb /var/notebooks
 
 
 # ==================================================================
+# Set up SSH for remote debug
+# ------------------------------------------------------------------
+
+# Setup environment for ssh session
+RUN  $APT_INSTALL openssh-server && \
+ echo "export PATH=$PATH" >> /etc/profile && \
+ echo "export LANG=$LANG" >> /etc/profile && \
+ echo "export LANGUAGE=$LANGUAGE" >> /etc/profile && \
+ echo "export LC_ALL=$LC_ALL" >> /etc/profile && \
+ echo "export PYTHONIOENCODING=$PYTHONIOENCODING" >> /etc/profile
+
+# Create folder for openssh fifos
+RUN mkdir -p /var/run/sshd
+
+# Disable password for root
+RUN sed -i -re 's/^root:[^:]+:/root::/' /etc/shadow
+RUN sed -i -re 's/^root:.*$/root::0:0:System Administrator:\/root:\/bin\/bash/' /etc/passwd
+
+# Permit root login over ssh
+RUN echo "Subsystem    sftp    /usr/lib/sftp-server \n\
+PasswordAuthentication yes\n\
+ChallengeResponseAuthentication yes\n\
+PermitRootLogin yes \n\
+PermitEmptyPasswords yes\n" > /etc/ssh/sshd_config
+
+# ssh port
+EXPOSE 22
+
+# ==================================================================
 # config & cleanup
 # ------------------------------------------------------------------
 


### PR DESCRIPTION
SSH was removed in [this PR](https://github.com/neuromation/neuro-base-environment/commit/c42d611411e05f77cca53030afbb7e3aebaefa8b). We still need it for [remote debugging via PyCharm](https://docs.neu.ro/toolbox/remote-debugging-with-pycharm-professional).